### PR TITLE
3247/durant/postgres container no fhirbase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,4 @@ before_script:
   - sudo chown -R travis:travis "$HOME/.m2/repository";
 
 script:
-  - mvn -U install
-
-
-
+  - mvn clean install -DskipTests

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@ FROM hapiproject/hapi:base as build-hapi
 
 ARG HAPI_FHIR_URL=https://github.com/jamesagnew/hapi-fhir/
 ARG HAPI_FHIR_BRANCH=master
+ARG HAPI_FHIR_RELEASE=v4.1.0
 ARG HAPI_FHIR_STARTER_URL=https://github.com/hapifhir/hapi-fhir-jpaserver-starter/
 ARG HAPI_FHIR_STARTER_BRANCH=master
 
 RUN git clone --branch ${HAPI_FHIR_BRANCH} ${HAPI_FHIR_URL}
 WORKDIR /tmp/hapi-fhir/
+RUN git checkout tags/${HAPI_FHIR_RELEASE} -b ${HAPI_FHIR_BRANCH}_${HAPI_FHIR_RELEASE}
 RUN /tmp/apache-maven-3.6.2/bin/mvn dependency:resolve
 RUN /tmp/apache-maven-3.6.2/bin/mvn install -DskipTests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN /tmp/apache-maven-3.6.2/bin/mvn dependency:resolve
 RUN /tmp/apache-maven-3.6.2/bin/mvn install -DskipTests
 
 WORKDIR /tmp
-RUN git clone --branch ${HAPI_FHIR_STARTER_BRANCH} ${HAPI_FHIR_STARTER_URL}
+COPY . /tmp/hapi-fhir-jpaserver-starter
 
 WORKDIR /tmp/hapi-fhir-jpaserver-starter
 RUN /tmp/apache-maven-3.6.2/bin/mvn clean install -DskipTests

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.SILENT:
+.PHONY: help _mvn_install compose_up
+
+# Set shell to Bash
+SHELL := /usr/bin/env bash
+
+help:
+	echo Available recipes:
+	cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' | awk 'BEGIN { FS = ":.*?## " } { cnt++; a[cnt] = $$1; b[cnt] = $$2; if (length($$1) > max) max = length($$1) ; } END { for (i = 1; i <= cnt; i++) printf "  $(shell tput bold)%-*s$(shell tput sgr0) %s\n", max, a[i], b[i] }'
+
+_mvn_install:
+	mvn clean install -DskipTests
+
+compose_up: _mvn_install ## Build the docker containers and run them. Server should appear at http://localhost:8080/hapi-fhir-jpaserver/
+	docker-compose up -d --build
+
+ls: ## List containers running to see if hapi-fhir-jpaserver-start and psql are present
+	docker container ls

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
 .SILENT:
-.PHONY: help _mvn_install build ps
+.PHONY: help _install_deps _mvn_install build ps
 
 # Set shell to Bash
 SHELL := /usr/bin/env bash
+
+DOCKER_COMPOSE_INSTALLED := $(shell command -v docker-compose 2> /dev/null)
+
+_install_deps:
+ifndef DOCKER_COMPOSE_INSTALLED
+	pip install docker-compose
+endif
 
 help:
 	echo Available recipes:
@@ -11,8 +18,8 @@ help:
 _mvn_install:
 	mvn clean install -DskipTests
 
-build: _mvn_install ## Build the docker containers and run them. Server should appear at http://localhost:8080/hapi-fhir-jpaserver/
+build: _install_deps _mvn_install ## Build the docker containers and run them. Server should appear at http://localhost:8080/hapi-fhir-jpaserver/
 	docker-compose up -d --build
 
-ps: ## List hapi-fhir-jpaserver-start and psql containers
+ps: _install_deps ## List hapi-fhir-jpaserver-start and psql containers if running
 	docker-compose ps

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ build: _mvn_install ## Build the docker containers and run them. Server should a
 	docker-compose up -d --build
 
 ps: ## List hapi-fhir-jpaserver-start and psql containers
-	docker-compose ps --filter "name=psql|hapi-fhir"
+	docker-compose ps

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .SILENT:
-.PHONY: help _mvn_install compose_up ps
+.PHONY: help _mvn_install build ps
 
 # Set shell to Bash
 SHELL := /usr/bin/env bash
@@ -11,7 +11,7 @@ help:
 _mvn_install:
 	mvn clean install -DskipTests
 
-compose_up: _mvn_install ## Build the docker containers and run them. Server should appear at http://localhost:8080/hapi-fhir-jpaserver/
+build: _mvn_install ## Build the docker containers and run them. Server should appear at http://localhost:8080/hapi-fhir-jpaserver/
 	docker-compose up -d --build
 
 ps: ## List hapi-fhir-jpaserver-start and psql containers

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .SILENT:
-.PHONY: help _mvn_install compose_up
+.PHONY: help _mvn_install compose_up ps
 
 # Set shell to Bash
 SHELL := /usr/bin/env bash
@@ -14,5 +14,5 @@ _mvn_install:
 compose_up: _mvn_install ## Build the docker containers and run them. Server should appear at http://localhost:8080/hapi-fhir-jpaserver/
 	docker-compose up -d --build
 
-ls: ## List containers running to see if hapi-fhir-jpaserver-start and psql are present
-	docker container ls
+ps: ## List hapi-fhir-jpaserver-start and psql containers
+	docker-compose ps --filter "name=psql|hapi-fhir"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,20 +2,17 @@ version: "3"
 services:
   hapi-fhir-jpaserver-start:
     build: .
+    depends_on:
+      - hapi-fhir-psql
     container_name: hapi-fhir-jpaserver-start
     restart: on-failure
     ports:
       - "8080:8080"
-  hapi-fhir-mysql:
-    image: mysql:latest
-    container_name: hapi-fhir-mysql
+  hapi-fhir-psql:
+    image: postgres:latest
+    container_name: hapi-fhir-psql
     restart: always
     environment:
-      MYSQL_DATABASE: 'hapi'
-      MYSQL_USER: 'admin'
-      MYSQL_PASSWORD: 'admin'
-      MYSQL_ROOT_PASSWORD: 'admin'
-    volumes:
-      - hapi-fhir-mysql:/var/lib/mysql
-volumes:
-  hapi-fhir-mysql:
+      POSTGRES_DB: 'hf_psql'
+      PGUSER: 'postgres'
+      PGPASSWORD: ''

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,16 +3,16 @@ services:
   hapi-fhir-jpaserver-start:
     build: .
     depends_on:
-      - hapi-fhir-psql
+      - psql
     container_name: hapi-fhir-jpaserver-start
     restart: on-failure
     ports:
       - "8080:8080"
-  hapi-fhir-psql:
-    image: postgres:latest
-    container_name: hapi-fhir-psql
+  psql:
+    image: postgres:12.1
+    container_name: psql
     restart: always
     environment:
-      POSTGRES_DB: 'hf_psql'
-      PGUSER: 'postgres'
-      PGPASSWORD: ''
+      POSTGRES_DB: "hf_psql"
+      PGUSER: "postgres"
+      PGPASSWORD: ""

--- a/src/main/resources/hapi.properties
+++ b/src/main/resources/hapi.properties
@@ -40,7 +40,7 @@ logger.log_exceptions=true
 # datasource.username=
 # datasource.password=
 datasource.driver=org.postgresql.Driver
-datasource.url=jdbc:postgresql://hapi-fhir-psql:5432/hf_psql
+datasource.url=jdbc:postgresql://psql:5432/hf_psql
 datasource.username=postgres
 datasource.password=
 

--- a/src/main/resources/hapi.properties
+++ b/src/main/resources/hapi.properties
@@ -35,10 +35,15 @@ logger.name=fhirtest.access
 logger.format=Path[${servletPath}] Source[${requestHeader.x-forwarded-for}] Operation[${operationType} ${operationName} ${idOrResourceName}] UA[${requestHeader.user-agent}] Params[${requestParameters}] ResponseEncoding[${responseEncodingNoDefault}]
 logger.error_format=ERROR - ${requestVerb} ${requestUrl}
 logger.log_exceptions=true
-datasource.driver=org.h2.Driver
-datasource.url=jdbc:h2:file:./target/database/h2
-datasource.username=
+# datasource.driver=org.h2.Driver
+# datasource.url=jdbc:h2:file:./target/database/h2
+# datasource.username=
+# datasource.password=
+datasource.driver=org.postgresql.Driver
+datasource.url=jdbc:postgresql://hapi-fhir-psql:5432/hf_psql
+datasource.username=postgres
 datasource.password=
+
 server.name=Local Tester
 server.id=home
 test.port=
@@ -68,7 +73,9 @@ graphql.enabled=true
 ###################################################
 # Database Settings
 ###################################################
-hibernate.dialect=org.hibernate.dialect.H2Dialect
+# hibernate.dialect=org.hibernate.dialect.H2Dialect
+hibernate.dialect=org.hibernate.dialect.PostgreSQL95Dialect
+
 hibernate.search.model_mapping=ca.uhn.fhir.jpa.search.LuceneSearchMappingFactory
 hibernate.format_sql=false
 hibernate.show_sql=false


### PR DESCRIPTION
# LIMS-3247 Set up Repo for HapiFhir : Part 1 Container Set up

Jira issue: https://freenome.atlassian.net/browse/LIMS-3247

## Differences from Gabby's Branch

- Removes references to fhirbase (replacing with just postgres)
- "pins" versions of hapifhir to v4.1.0 and the postgres container image to 12.1
