### PR TITLE
WIP PTS-67,68 [Testing Infra] Repository for inferno tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,9 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ jdk:
 before_install:
   - openssl aes-256-cbc -K $encrypted_768cddeffb19_key -iv $encrypted_768cddeffb19_iv
     -in .travis/sa.json.enc -d | docker login -u _json_key --password-stdin https://gcr.io
-install: "/bin/true"
+install:
+  - "pip install pytest"
 before_script:
   - export MAVEN_SKIP_RC=true
   - sudo chmod -R 777 "$HOME/.m2/repository";

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
 script:
   - mvn clean install -DskipTests
   - ".travis/test run_server"
+  - "make test"
 cache:
   directories:
     - "$HOME/.m2/repository"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ jdk:
 before_install:
   - openssl aes-256-cbc -K $encrypted_768cddeffb19_key -iv $encrypted_768cddeffb19_iv
     -in .travis/sa.json.enc -d | docker login -u _json_key --password-stdin https://gcr.io
-install:
-  - "pip install pytest"
+install: "/bin/true"
 before_script:
   - export MAVEN_SKIP_RC=true
   - sudo chmod -R 777 "$HOME/.m2/repository";

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,14 @@
 SHELL := /usr/bin/env bash
 
 DOCKER_COMPOSE_INSTALLED := $(shell command -v docker-compose 2> /dev/null)
+PYTEST_INSTALLED := $(shell pip show pytest 2> /dev/null)
 
 _install_deps:
 ifndef DOCKER_COMPOSE_INSTALLED
 	pip install docker-compose
+endif
+ifndef PYTEST_INSTALLED
+	pip install pytest
 endif
 
 help:
@@ -24,5 +28,5 @@ run: _install_deps _mvn_install ## Build the docker containers and run them. Ser
 ps: _install_deps ## List hapi-fhir-jpaserver-start and psql containers if running
 	docker-compose ps
 
-test: ## execute tests which rely on server locally running on http://localhost:8080/hapi-fhir-jpaserver/
+test: _install_deps ## execute tests which rely on server locally running on http://localhost:8080/hapi-fhir-jpaserver/
 	python -m pytest --durations=0 tests

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .SILENT:
-.PHONY: help _install_deps _mvn_install run ps
+.PHONY: help _install_deps _mvn_install run ps test
 
 # Set shell to Bash
 SHELL := /usr/bin/env bash
@@ -23,3 +23,6 @@ run: _install_deps _mvn_install ## Build the docker containers and run them. Ser
 
 ps: _install_deps ## List hapi-fhir-jpaserver-start and psql containers if running
 	docker-compose ps
+
+test: ## execute tests which rely on server locally running on http://localhost:8080/hapi-fhir-jpaserver/
+	python -m pytest --durations=0 tests

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -5,7 +5,7 @@ import requests
 URL = "http://localhost:8080/hapi-fhir-jpaserver/fhir/"
 
 
-def test_GET_organizaiton_random_unknown_name_fail():
+def test_GET_organization_random_unknown_name_fail():
     non_existent_name = f"SHOULD-NOT-EXIST-{random.random()}"
     # URL similar to "http://localhost:8080/hapi-fhir-jpaserver/fhir/Organization?name=SHOULD-NOT-EXIST-0.9383671425079436"
     response = requests.get(URL + "Organization", params={"name": non_existent_name})

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -1,0 +1,12 @@
+import pytest
+import random
+import requests
+
+URL = "http://localhost:8080/hapi-fhir-jpaserver/fhir/"
+
+
+def test_GET_organizaiton_random_unknown_name_fail():
+    non_existent_name = f"SHOULD-NOT-EXIST-{random.random()}"
+    # URL similar to "http://localhost:8080/hapi-fhir-jpaserver/fhir/Organization?name=SHOULD-NOT-EXIST-0.9383671425079436"
+    response = requests.get(URL + "Organization", params={"name": non_existent_name})
+    assert response.status_code == 200, response.json()


### PR DESCRIPTION
# PTS-67,68 [Testing Infra] Repository for inferno tests

**Update:** This repo actually contains both changes for PTS-67 & PTS-68. Since the PTS-68 (travis) portion is blocked, I'm separating these out properly. See https://github.com/freenome/hapi-fhir-jpaserver-starter/pull/10 for the PTS-67 portion only.

@mattmahowald hopefully this simple set is what you have in mind. I haven't testing calling "make test" in travis, so we'll see how that goes as this runs in travis for this PR.

@jasneet-fn I set this up in a top level `tests/` directory as we discussed (instead of `src/test/python`) as we discussed, although I could probably go either way on that since we can run it with `make test`. Feel free to approve this if `tests/` works for you.

Jira issue: https://freenome.atlassian.net/browse/PTS-67

As this is, `make test` passes after `make run` is called and the server is locally running.

- uses top-level `tests/` directory
- one simple test which fails as expected on a GET of a non-existent organization
- `make test` implemented
- `.travis.yml` calls `make test` in test section
- updates to .gitignore for python files
